### PR TITLE
New rule parsing system, allows every possible key combination!

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -1,0 +1,115 @@
+var util = require('util');
+var fs = require('fs');
+var rules = [];
+var re = /^((?:[a-z_]+-)*)(.*)$/;
+
+module.exports = {
+    reload: function() {
+        fs.exists('rules.json', function() {
+            try {
+                rules = JSON.parse(fs.readFileSync('rules.json', 'utf8'));
+                console.log('(Re)loaded rules.json');
+            } catch (ex) {
+                console.log('Could not load rules.json');
+                console.log(ex);
+            }
+        });
+    },
+
+    resolve: function(search) {
+        var match = re.exec(search);
+        var key = match[2];
+        var result = null;
+        var resolved_rule = null;
+        var modifiers = match[1].split('-').filter(Boolean);
+
+        // some() is used to stop iteration as soon as we found a matching rule
+        rules.some(function(rule) {
+            var test_key = key; // key on which rules are to be matched against
+            var value = null;   // match result
+
+            if (rule.modifiers != null) {
+                // check that all specified modifiers are allowed
+                // and are in the right place
+                // otherwise, abort this rule
+                var rule_modifier_min_index = 0;
+                if (modifiers.some(function(mod) {
+                    var rule_modifier_index = rule.modifiers.indexOf(mod);
+                    if (rule_modifier_index >= rule_modifier_min_index) {
+                        rule_modifier_min_index = rule_modifier_index + 1;
+                        return false;
+                    }
+                    return true;
+                }))
+                {
+                    return false; // continue some() loop
+                }
+            } else {
+                // If no modifiers are allowed, use the full search as key, instead of the one
+                // without modifiers (ctrl-c rather than c)
+                // This is to allow rules such as "ctrl-c" when modifiers is not set.
+                test_key = search;
+            }
+
+            if (rule.type == "simple") {
+                if (rule.list && rule.indexOf(test_key) != -1) {
+                    value = test_key;
+                } else if (rule.map && rule.map[test_key] != null) {
+                    value = rule.map[test_key];
+                }
+            } else if (rule.type == "regex") {
+                // Try matching against the rule.list regexes first
+                // The resulting value is the key itself
+                if (rule.list != null) {
+                    rule.list.some(function(regex) {
+                        if (test_key.match("^" + regex + "$")) {
+                            value = test_key;
+                            return true;
+                        } else {
+                            return false;
+                        }
+                    });
+                }
+
+                // If not successful, match against the rule.map regexes
+                // The key is the regexp to match against the key
+                // The value is the corresponding value in the map
+                // with $0 replaced by the key
+                if (value == null && rule.map != null) {
+                    Object.keys(rule.map).some(function(x) {
+                        var m = test_key.match("^" + x + "$");
+                        if (m == null) {
+                            return false;
+                        }
+                        value = rule.map[x].replace("$0", test_key);
+                        return true;
+                    });
+                }
+            }
+            if (value == null) {
+                // rule didn't match, continue to next one
+                return false;
+            } else {
+                if (rule.modifiers != null) {
+                    // add the used modifiers in front of the value
+                    // only if modifiers are allowed
+                    value = modifiers.concat(value).join("-");
+                }
+                // build the final command from the rule.command and value
+                // value is lowercased so that "X" will yield "shift-x", not "shift-X"
+                // "VOTE" must be part of rule.command (not value) so that it isn't lowercased
+                result = rule.command.replace("$0", value.toLowerCase());
+                resolved_rule = rule;
+                return true;
+            }
+        });
+
+        if (result == null) {
+            return null;
+        }
+
+        return result;
+    }
+};
+
+module.exports.reload();

--- a/rules.json
+++ b/rules.json
@@ -1,0 +1,113 @@
+[
+    {
+      "name": "No-op commands",
+      "type" : "simple",
+      "command": "$0",
+      "map" : {
+        "yes": "",
+        "nop": ""
+      }
+    },
+    {
+      "name" : "Dangerous key combinations (require voting)",
+      "type": "regex",
+      "command": "VOTE $0",
+      "map": {
+        "(?:shift-)?(?:meta_l-)?ctrl-(?:alt-)?c": "sendkey $0",
+        "(?:meta_l-)?ctrl-(?:alt-)?C": "sendkey shift-$0"
+      }
+    },
+    {
+      "name": "Special commands (require voting)",
+      "type" : "simple",
+      "command": "VOTE $0",
+      "map" : {
+        "system_reset": "system_reset",
+        "boot_cd": "boot_set dc",
+        "boot_drive": "boot_set cd",
+        "democracy": "democracy",
+        "anarchy": "anarchy"
+      }
+    },
+    {
+      "name": "Function keys (all modifiers allowed)",
+      "type": "regex",
+      "modifiers": [ "shift", "meta_l", "ctrl", "alt" ],
+      "command": "sendkey $0",
+      "list": [ "f[1-9]|f1[0-2]" ]
+    },
+    {
+      "name": "Uppercase letters (no shift)",
+      "type": "regex",
+      "modifiers": [ "meta_l", "ctrl", "alt" ],
+      "command": "sendkey shift-$0",
+      "list": [ "[A-Z]" ]
+    },
+    {
+      "name": "Numbers and lowercase letters (shift not allowed)",
+      "type": "regex",
+      "modifiers": [ "meta_l", "ctrl", "alt" ],
+      "command": "sendkey $0",
+      "list": [ "[a-z0-9]" ]
+    },
+    {
+      "name": "Special keys (all modifiers)",
+      "type" : "simple",
+      "modifiers" : [ "shift", "meta_l", "ctrl", "alt" ],
+      "command": "sendkey $0",
+      "map" : {
+        "escape" : "esc",
+        "backspace": "backspace",
+        "tab": "tab",
+        "enter": "ret",
+        "space": "spc",
+        "up": "up",
+        "down": "down",
+        "left": "left",
+        "right": "right"
+      }
+    },
+    {
+      "name": "Symbols (no shift)",
+      "type" : "simple",
+      "modifiers": [ "meta_l", "ctrl", "alt" ],
+      "command": "sendkey $0",
+      "map" : {
+        "`": "grave_accent",
+        "~": "shift-grave_accent",
+        "!": "shift-1",
+        "at": "shift-2",
+        "#": "shift-3",
+        "$": "shift-4",
+        "%": "shift-5",
+        "^": "shift-6",
+        "&": "shift-7",
+        "*": "shift-8",
+        "(": "shift-9",
+        ")": "shift-0",
+        "-": "minus",
+        "_": "shift-minus",
+        "=": "equal",
+        "+": "shift-equal",
+
+        "[": "bracket_left",
+        "{": "shift-bracket_left",
+        "]": "bracket_right",
+        "}": "shift-bracket_right",
+        "backslash": "backslash",
+        "|": "shift-backslash",
+
+        ";": "semicolon",
+        ":": "shift-semicolon",
+        "'": "apostrophe",
+        "\"": "shift-apostrophe",
+
+        ",": "comma",
+        "<": "shift-comma",
+        "dot": "dot",
+        ">": "shift-dot",
+        "slash": "slash",
+        "?": "shift-slash"
+      }
+    }
+  ]

--- a/test_rules.js
+++ b/test_rules.js
@@ -1,0 +1,51 @@
+// This program makes sures the legacy map of commands give the
+// same result in the new rule system
+var fs  = require('fs');
+var rules = require('./lib/rules');
+var util = require('util');
+
+var TIMEOUT = 500;
+
+// Load json command mapping
+var map = {}
+
+function map_load() {
+  fs.exists('map.json', function() {
+    try {
+      var map_new = JSON.parse(fs.readFileSync('map.json', 'utf8'));
+      map = map_new;
+      console.log('(Re)loaded map.json');
+    } catch (ex) {
+      console.log('Could not load map.json');
+      console.log(ex);
+    }
+  });
+}
+
+map_load();
+
+setTimeout(function() {
+  var keys = Object.keys(map);
+  var errors = [];
+
+  keys.forEach(function(x) {
+    var resolved = rules.resolve(x);
+    if (resolved !== map[x]) {
+      errors.push([x, resolved, map[x]]);
+    }
+  });
+
+  if (errors.length != 0) {
+    console.log("Some keys did not match:");
+    errors.forEach(function(x) {
+      console.log("key: " + x[0] + ", got: " + x[1] + ", expected: " + x[2]);
+    });
+  } else {
+    console.log("All keys match!");
+  }
+}, TIMEOUT);
+
+process.stdin.on('data', function(d) {
+  data = d.toString().trim();
+  console.log(data + ": " + rules.resolve(data));
+});


### PR DESCRIPTION
Allows shift, meta_l, ctrl, alt modifiers (in that order only)

Letters keys (ctrl-a, ctrl-b...) can be capitalized (ctrl-A) but no shift modifier is allowed (shift-ctrl-a)

Valid combinations:
 * q (sendkey q)
 * Q (sendkey shift-q)
 * meta_l-ctrl-alt-q (sendkey meta_l-ctrl-alt-q)
 * meta_l-ctrl-alt-Q (sendkey shift-meta_l-ctrl-alt-q)
 * at (sendkey shift-2)
 * meta_l-ctrl-alt-at (sendkey shift-meta_l-ctrl-alt-q)
 * shift-meta_l-ctrl-alt-f1 (sendkey shift-meta_l-ctrl-alt-f1)
 * shift-up (sendkey shift-up)
 * ctrl-backspace (sendkey ctrl-backspace)
 * etc.

Disallowed combinations:
 * shift-Q (use Q)
 * shift-ctrl-q (use ctrl-Q)
 * alt-ctrl-q (use ctrl-alt-q)
 * ctrl-alt-shift-down (use shift-ctrl-alt-down)

This also addresses the issues in PR #17 and #18.